### PR TITLE
Add type diagram plugin

### DIFF
--- a/list/visualization/jadx-type-diagram-plugin.json
+++ b/list/visualization/jadx-type-diagram-plugin.json
@@ -1,0 +1,3 @@
+{
+  "locationId": "github:timschneeb:jadx-type-diagram-plugin"
+}


### PR DESCRIPTION
This plugin adds a context menu item to generate an interactive class/type diagram for a type.

https://github.com/timschneeb/jadx-type-diagram-plugin