### PR TITLE
Add native libraries plugin

### DIFF
--- a/list/other/native-libraries-plugin.json
+++ b/list/other/native-libraries-plugin.json
@@ -1,0 +1,3 @@
+{
+	"locationId": "github:andyjsmith:jadx-native-libraries-plugin"
+}


### PR DESCRIPTION
Adds a plugin for viewing information about the native JNI (.so) libraries in APKs, specifically what Java methods they export.

https://github.com/andyjsmith/jadx-native-libraries-plugin
