### PR TITLE
Add jadx-magic-strings.json configuration file.

### DIFF
--- a/list/other/jadx-magic-strings.json
+++ b/list/other/jadx-magic-strings.json
@@ -1,0 +1,3 @@
+{
+  "locationId": "github:0rshemesh:jadx-magic-strings"
+}


### PR DESCRIPTION
# JADX Magic Strings Plugin

So I built this JADX plugin that I've been finding really useful for reverse engineering Android apps. You know how sometimes you're digging through decompiled code and you spot a string that looks like a file path or a method name? This plugin finds all of those automatically.

It basically scans through all the string constants after JADX finishes decompiling and picks out:
- Source file references (like `.java` or `.kt` paths that sometimes leak through)
- Method name candidates (from error messages, debug strings, etc.)
- All strings with their context (which method/class they're in)

The GUI shows everything in a few different views so you can browse by source file, see top candidates, or just search through all strings. Pretty handy when you're trying to figure out what an app does or recover obfuscated names.

Thanks to @skylot  for the tip that helped improve the plugin!


Install it with:
```bash
jadx plugins --install "github:0rshemesh:jadx-magic-strings"
```

Or grab it from https://github.com/0rShemesh/jadx-magic-strings

Had fun writing it, hope someone else finds it useful too!