### PR TITLE
jadx-ollama-assist plugin

### DIFF
--- a/list/llm/jadx-ollama-plugin.json
+++ b/list/llm/jadx-ollama-plugin.json
@@ -1,0 +1,3 @@
+{
+  "locationId": "github:SteynDewald:jadx-ollama-assist"
+}


### PR DESCRIPTION
Release Notes
1.0.0 - 2026-04-11
Initial public production release of Jadx Ollama Assist.

Highlights
Added Jadx GUI plugin integration for local Ollama model analysis
Implemented custom prompt UI and mode-based code guidance
Added configuration dialog for Ollama endpoint, model, and temperature
Included issue templates for bug reporting and feature requests
Published with MIT license and author attribution
Notes
This release is intended for lawful reverse engineering, security research, and developer productivity. It is not designed to support software piracy or illegal distribution.

Plugin page: https://github.com/SteynDewald/jadx-ollama-assist