### PR TITLE
add `jadx-string-decoder` jadx plugin

### DIFF
--- a/list/other/jadx-string-decoder.json
+++ b/list/other/jadx-string-decoder.json
@@ -1,0 +1,3 @@
+{
+    "locationId": "github:nklapste:jadx-string-decoder"
+}


### PR DESCRIPTION
A JADX plugin that detects likely encoded string constants during decompilation and annotates them with decoded comments inline.

https://github.com/nklapste/jadx-string-decoder